### PR TITLE
update log to use kv_unstable_std instead of std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,9 +362,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+checksum = "fcf3805d4480bb5b86070dcfeb9e2cb2ebc148adb753c5cca5f884d1d65a42b2"
 dependencies = [
  "cfg-if 0.1.10",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
 shared_arena = "0.8"
 itertools = "0.9"
-log = { version = "0.4", features = ["max_level_trace", "release_max_level_trace", "kv_unstable_std"] }
+log = { version = "0.4.13", features = ["max_level_trace", "release_max_level_trace", "kv_unstable_std"] }
 kv-log-macro = "1"
 serde_json = "1"
 chrono = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
 shared_arena = "0.8"
 itertools = "0.9"
-log = { version = "0.4", features = ["max_level_trace", "release_max_level_trace", "std", "kv_unstable"] }
+log = { version = "0.4", features = ["max_level_trace", "release_max_level_trace", "kv_unstable_std"] }
 kv-log-macro = "1"
 serde_json = "1"
 chrono = "0.4"


### PR DESCRIPTION
Part of https://github.com/rust-lang/log/issues/437

The `log` crate has an unstable structured logging API under the `kv_unstable` feature. In previous releases, if you specified both the `kv_unstable` and `std` features of `log` like so:

```toml
log = { features = ["std", "kv_unstable"]}
```

you'd get support for standard library types in `log`'s structured logging API.

Going forward, this functionality is now gated under `kv_unstable_std`:

```toml
log = { features = ["kv_unstable_std"]}
```

This change was made because we need to enable features in optional dependencies when both the `std` and `kv_unstable` features are enabled, which isn't currently supported by Cargo.

This PR updates this library to follow the new approach. It can be merged at any time and is currently non-blocking, but on 2020-01-18 the version of `log` requiring `kv_unstable_std` instead of `kv_unstable` and `std` will be published.

Thanks for trying out `log`'s structured logging API and sorry for any disruption! :bow: